### PR TITLE
Small Slack adapter fix for reading from WebSocket.

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -38,7 +38,7 @@ if (!(Test-Path $NUGET_EXE)) {
 # Restore tools from NuGet.
 Push-Location
 Set-Location $TOOLS_DIR
-Invoke-Expression "$NUGET_EXE install -ExcludeVersion"
+Invoke-Expression "$NUGET_EXE install -ExcludeVersion -Source https://www.nuget.org/api/v2"
 Pop-Location
 if ($LASTEXITCODE -ne 0) {
     exit $LASTEXITCODE


### PR DESCRIPTION
The Slack adapter did not read until end of message and therefore sometimes tried to parse an incomplete JSON object.

The fix reads until `WebSocket.EndOfMessage` and writes to a temporary `MemoryStream`.