### PR TITLE
Add support for OnConnected and OnDisconnected.

### DIFF
--- a/src/NuBot.Hosts.CommandLine/Program.cs
+++ b/src/NuBot.Hosts.CommandLine/Program.cs
@@ -5,6 +5,7 @@ using NuBot.Factory;
 using NuBot.Parts;
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace NuBot.Hosts.CommandLine
 {
@@ -12,33 +13,79 @@ namespace NuBot.Hosts.CommandLine
     {
         public static void Main(string[] args)
         {
-            IAdapter adapter = null;
+            Console.TreatControlCAsInput = true;
+            new Program().Run(args);
+        }
 
-            switch(args[0])
+        public void Run(string[] args)
+        {
+            var resetEvent = new ManualResetEvent(false);
+            var tokenSource = new CancellationTokenSource();
+
+            var thread = new Thread(() =>
             {
-                case "gitter":
-                    adapter = new GitterAdapter(args[1]);
-                    break;
+                try
+                {
+                    IAdapter adapter;
 
-                case "slack":
-                    adapter = new SlackAdapter(args[1]);
-                    break;
+                    switch (args[0])
+                    {
+                        case "gitter":
+                            adapter = new GitterAdapter(args[1]);
+                            break;
 
-                default:
-                    throw new NotImplementedException("Unknown NuBot adapter.");
+                        case "slack":
+                            adapter = new SlackAdapter(args[1]);
+                            break;
+
+                        default:
+                            throw new NotImplementedException("Unknown NuBot adapter.");
+                    }
+
+                    new RobotFactory()
+                        .AddPart<Echo>()
+                        .AddPart<EchoWebHook>()
+                        .AddPart<HelloGoodbye>()
+                        .AddPart<IllBeBack>()
+                        .UseAdapter(adapter)
+                        //.UserHttpServer(1337)
+                        .RunAsync(tokenSource.Token)
+                        .GetAwaiter()
+                        .GetResult();
+                }
+                catch (OperationCanceledException)
+                {
+                }
+                catch (Exception exception)
+                {
+                    Console.ForegroundColor = ConsoleColor.Red;
+                    Console.WriteLine(exception);
+                    Console.ResetColor();
+                }
+                finally
+                {
+                    resetEvent.Set();
+                }
+            });
+
+            thread.Start();
+
+            while (true)
+            {
+                var key = Console.ReadKey(true);
+
+                if ((key.Modifiers & ConsoleModifiers.Control) == ConsoleModifiers.Control && key.Key == ConsoleKey.C)
+                {
+                    break;
+                }
             }
 
-            var cancellationToken = CancellationToken.None;
+            tokenSource.Cancel();
+            resetEvent.WaitOne();
+            thread.Join();
 
-            new RobotFactory()
-                .AddPart<Echo>()
-                .AddPart<EchoWebHook>()
-                .AddPart<HelloGoodbye>()
-                .UseAdapter(adapter)
-                .UserHttpServer(1337)
-                .RunAsync(cancellationToken)
-                .GetAwaiter()
-                .GetResult();
+            Console.WriteLine("NuBot has stopped.");
+            Console.ReadKey();
         }
     }
 }

--- a/src/NuBot/Adapters/Slack/SlackAdapter.cs
+++ b/src/NuBot/Adapters/Slack/SlackAdapter.cs
@@ -92,8 +92,6 @@ namespace NuBot.Adapters.Slack
                         } while (!result.EndOfMessage);
 
                         ms.Seek(0, SeekOrigin.Begin);
-                        var json = Encoding.UTF8.GetString(ms.ToArray());
-
                         HandleEvent(ms);
                     }
                 }

--- a/src/NuBot/Automation/Contexts/Context.cs
+++ b/src/NuBot/Automation/Contexts/Context.cs
@@ -5,11 +5,11 @@ using NuBot.Adapters;
 
 namespace NuBot.Automation.Contexts
 {
-    internal abstract class Context : IContext
+    internal class Context : IContext
     {
         private readonly IAdapter _adapter;
 
-        protected Context(IAdapter adapter)
+        public Context(IAdapter adapter)
         {
             if (adapter == null) throw new ArgumentNullException(nameof(adapter));
             _adapter = adapter;

--- a/src/NuBot/Automation/IRobot.cs
+++ b/src/NuBot/Automation/IRobot.cs
@@ -19,6 +19,10 @@ namespace NuBot.Automation
 
         void OnChannelLeave(Action<ISourcedContext<IChannelLeaveMessage>> context);
 
+        void OnConnected(Action<IContext> context);
+
+        void OnDisconnected(Action<IContext> context);
+
         T Random<T>(IEnumerable<T> collection);
 
         void WebHook(string method, string pattern, Action<IWebHookContext> context);

--- a/src/NuBot/Automation/Robot.cs
+++ b/src/NuBot/Automation/Robot.cs
@@ -55,6 +55,22 @@ namespace NuBot.Automation
                     new MatchAllFilter<IChannelLeaveMessage>()));
         }
 
+        public void OnConnected(Action<IContext> context)
+        {
+            _engine.RegisterExecutor(
+                new TaggedContextExecutor(
+                    context,
+                    TaggedContextExecutor.Connected));
+        }
+
+        public void OnDisconnected(Action<IContext> context)
+        {
+            _engine.RegisterExecutor(
+                new TaggedContextExecutor(
+                    context,
+                    TaggedContextExecutor.Disconnected));
+        }
+
         public T Random<T>(IEnumerable<T> collection)
         {
             var arr = collection.ToArray();

--- a/src/NuBot/Automation/TaggedContextExecutor.cs
+++ b/src/NuBot/Automation/TaggedContextExecutor.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using NuBot.Automation.Contexts;
+
+namespace NuBot.Automation
+{
+    public class TaggedContextExecutor : IContextExecutor
+    {
+        // Pre-defined tags
+        public static readonly string Connected = "Connected";
+        public static readonly string Disconnected = "Disconnected";
+
+        private readonly Action<IContext> _contextCallback;
+
+        public TaggedContextExecutor(Action<IContext> contextCallback, string tag)
+        {
+            if (contextCallback == null) throw new ArgumentNullException(nameof(contextCallback));
+            if (tag == null) throw new ArgumentNullException(nameof(tag));
+            _contextCallback = contextCallback;
+            Tag = tag;
+        }
+
+        public string Tag { get; }
+
+        public void Execute(IExecutionRequest request)
+        {
+            var context = new Context(request.Adapter);
+            _contextCallback(context);
+        }
+    }
+}

--- a/src/NuBot/NuBot.csproj
+++ b/src/NuBot/NuBot.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Adapters\Slack\Models\Group.cs" />
     <Compile Include="Adapters\Slack\Models\Im.cs" />
     <Compile Include="Adapters\Slack\User.cs" />
+    <Compile Include="Automation\TaggedContextExecutor.cs" />
     <Compile Include="Automation\Contexts\Context.cs" />
     <Compile Include="Automation\Contexts\ContextExtensions.cs" />
     <Compile Include="Automation\Contexts\SourcedContext.cs" />
@@ -102,6 +103,7 @@
     <Compile Include="Http\NullHttpServer.cs" />
     <Compile Include="Parts\Echo.cs" />
     <Compile Include="Parts\HelloGoodbye.cs" />
+    <Compile Include="Parts\IllBeBack.cs" />
     <Compile Include="Parts\Ping.cs" />
     <Compile Include="Parts\DoIt.cs" />
     <Compile Include="Parts\ShipIt.cs" />

--- a/src/NuBot/Parts/IllBeBack.cs
+++ b/src/NuBot/Parts/IllBeBack.cs
@@ -1,0 +1,20 @@
+﻿using NuBot.Automation;
+
+namespace NuBot.Parts
+{
+    public class IllBeBack : RobotPart
+    {
+        public override void Attach(IRobot robot)
+        {
+            robot.OnConnected(async ctx =>
+            {
+                await ctx.BroadcastAsync("I'm back.");
+            });
+
+            robot.OnDisconnected(async ctx =>
+            {
+                await ctx.BroadcastAsync("I'll be back.");
+            });
+        }
+    }
+}


### PR DESCRIPTION
This adds support for a Robot Part (TM) to broadcast messages when NuBot connects and disconnects to/from the adapter.

Example

```
public override void Attach(IRobot robot)
{
    robot.OnConnected(async ctx =>
    {
        await ctx.BroadcastAsync("I'm back.");
    });

    robot.OnDisconnected(async ctx =>
    {
        await ctx.BroadcastAsync("I'll be back.");
    });
}
```