### PR TITLE
Fix HTTP server cancellation

### DIFF
--- a/src/NuBot.Hosts.CommandLine/Program.cs
+++ b/src/NuBot.Hosts.CommandLine/Program.cs
@@ -48,7 +48,7 @@ namespace NuBot.Hosts.CommandLine
                         .AddPart<HelloGoodbye>()
                         .AddPart<IllBeBack>()
                         .UseAdapter(adapter)
-                        //.UserHttpServer(1337)
+                        .UseHttpServer(1337)
                         .RunAsync(tokenSource.Token)
                         .GetAwaiter()
                         .GetResult();

--- a/src/NuBot/Factory/RobotFactory.cs
+++ b/src/NuBot/Factory/RobotFactory.cs
@@ -40,7 +40,7 @@ namespace NuBot.Factory
             return this;
         }
 
-        public RobotFactory UserHttpServer(int port, string host = "localhost")
+        public RobotFactory UseHttpServer(int port, string host = "localhost")
         {
             _httpServer = new HttpServer(port, host);
             return this;

--- a/src/NuBot/Http/HttpServer.cs
+++ b/src/NuBot/Http/HttpServer.cs
@@ -31,20 +31,47 @@ namespace NuBot.Http
             _listener.Prefixes.Add($"http://{_host}:{_port}/nubot/");
             _listener.Start();
 
-            while (!cancellationToken.IsCancellationRequested)
+            _listener.BeginGetContext(GetContext, null);
+
+            try
             {
-                var ctx = await _listener.GetContextAsync();
-
-                foreach (var callback in _callbacks)
-                {
-                    callback(ctx);
-                }
-
-                ctx.Response.StatusCode = 200;
-                ctx.Response.OutputStream.Close();
+                await Task.Delay(Timeout.Infinite, cancellationToken);
+            }
+            catch (TaskCanceledException)
+            {
             }
 
             _listener.Stop();
+        }
+
+        private void GetContext(IAsyncResult ar)
+        {
+            HttpListenerContext ctx;
+
+            try
+            {
+                ctx = _listener.EndGetContext(ar);
+            }
+            catch (HttpListenerException httpException)
+            {
+                // 995 is operation aborted
+                if (httpException.ErrorCode == 995)
+                {
+                    return;
+                }
+
+                throw;
+            }
+
+            foreach (var callback in _callbacks)
+            {
+                callback(ctx);
+            }
+
+            ctx.Response.StatusCode = 200;
+            ctx.Response.OutputStream.Close();
+
+            _listener.BeginGetContext(GetContext, null);
         }
     }
 }


### PR DESCRIPTION
This implements the HTTP server with the old BeginGetContext/EndGetContext and just waits on a task to cancel before stopping.

Closes #9 